### PR TITLE
Made improvements to the context menu.

### DIFF
--- a/vimage/Source/Config.cs
+++ b/vimage/Source/Config.cs
@@ -14,6 +14,7 @@ BackgroundForImagesWithTransparencyDefault = 0
 LimitImagesToMonitorHeight = 1
 PositionLargeWideImagesInCorner = 1 // ie: Desktop Wallpapers and Screenshots
 ContextMenuShowMargin = 0 // shows checkboxes for certain menu items
+ContextMenuColors = 1 // colorize the context menu
 PreloadNextImage = 1 // when using the next/prev image buttons, the image after the one just loaded will be loaded as well ready
 
 Drag = MOUSELEFT
@@ -70,6 +71,7 @@ Delete = DELETE";
         public bool Setting_LimitImagesToMonitorHeight { get { return (Boolean)Settings["LIMITIMAGESTOMONITORHEIGHT"]; } }
         public bool Setting_PositionLargeWideImagesInCorner { get { return (Boolean)Settings["POSITIONLARGEWIDEIMAGESINCORNER"]; } }
         public bool Setting_ContextMenuShowMargin { get { return (Boolean)Settings["CONTEXTMENUSHOWMARGIN"]; } }
+        public bool Setting_ContextMenuColors { get { return (Boolean)Settings["CONTEXTMENUCOLORS"]; } }
         public bool Setting_PreloadNextImage { get { return (Boolean)Settings["PRELOADNEXTIMAGE"]; } }
 
         private Dictionary<string, object> Settings;
@@ -114,6 +116,7 @@ Delete = DELETE";
                 { "LIMITIMAGESTOMONITORHEIGHT", true },
                 { "POSITIONLARGEWIDEIMAGESINCORNER", true },
                 { "CONTEXTMENUSHOWMARGIN", false},
+                { "CONTEXTMENUCOLORS", true},
                 { "PRELOADNEXTIMAGE", true},
 
                 { "DRAG", Control_Drag },

--- a/vimage/Source/ImageViewer.cs
+++ b/vimage/Source/ImageViewer.cs
@@ -116,7 +116,7 @@ namespace vimage
                 "-"
             });
 
-            SetupContextMenu();
+            SetupContextMenu(false);
 
             // Create Window
             Window = new RenderWindow(new VideoMode(Image.Texture.Size.X, Image.Texture.Size.Y), File + " - vimage", Styles.None);
@@ -254,6 +254,7 @@ namespace vimage
                     PreloadNextImage();
             }
         }
+
         private void Redraw()
         {
             // Clear screen
@@ -280,9 +281,9 @@ namespace vimage
             NextWindowPos = Window.Position; // Refresh the NextWindowPos var just in case the thing that induced the update didn't change the window position
         }
 
-        private void SetupContextMenu()
+        private void SetupContextMenu(bool force)
         {
-            if ((ContextMenuSetting == 0 && !(Image is AnimatedImage)) || (ContextMenuSetting == 1 && Image is AnimatedImage))
+            if (!force && ((ContextMenuSetting == 0 && !(Image is AnimatedImage)) || (ContextMenuSetting == 1 && Image is AnimatedImage)))
                 return;
 
             ContextMenu.Items.Clear();
@@ -301,6 +302,7 @@ namespace vimage
             }
 
             int c = 0;
+            bool contextMenuColors = Config.Setting_ContextMenuColors;
             for (int i = 0; i < items.Count; i++)
             {
                 System.Windows.Forms.ToolStripItem item = ContextMenu.Items.Add(items[i]);
@@ -311,7 +313,7 @@ namespace vimage
                 item.Click += ContexMenuItemClicked;
 
                 c++;
-                if (c % 2 == 0)
+                if (c % 2 == 0 && contextMenuColors)
                     ContextMenu.Items[i].BackColor = System.Drawing.Color.LightBlue;
             }
 
@@ -407,8 +409,7 @@ namespace vimage
             // Reload Config
             if (Config.IsControl(code, Config.Control_ReloadConfig))
             {
-                Config.Init();
-                Config.Load(AppDomain.CurrentDomain.BaseDirectory + "config.txt");
+                ReloadConfig();
             }
 
             // Toggle Settings
@@ -490,7 +491,7 @@ namespace vimage
                 case "Delete": DeleteFile(); break;
 
                 case "Open Config.txt": Process.Start(AppDomain.CurrentDomain.BaseDirectory + "config.txt"); break;
-                case "Reload Config.txt": Config.Init(); Config.Load(AppDomain.CurrentDomain.BaseDirectory + "config.txt"); break;
+                case "Reload Config.txt": ReloadConfig(); break;
 
                 case VERSION_NAME: Process.Start("http://torrunt.net/vimage"); break;
             }
@@ -807,7 +808,7 @@ namespace vimage
             ForceAlwaysOnTopNextTick = true;
 
             Window.SetTitle(fileName + " - vimage");
-            SetupContextMenu();
+            SetupContextMenu(false);
 
             return true;
         }
@@ -936,6 +937,13 @@ namespace vimage
         private void OpenFileAtLocation()
         {
             Process.Start("explorer.exe", "/select, " + File);
+        }
+
+        private void ReloadConfig()
+        {
+            Config.Init();
+            Config.Load(AppDomain.CurrentDomain.BaseDirectory + "config.txt");
+            SetupContextMenu(true);
         }
 
     }


### PR DESCRIPTION
- Added option to disable even/odd coloring

Personally I can't stand the colored context menu. It took my eyes a moment to figure out what was even going on when I first opened it. I added an option to removed the even/odd coloring, while keeping the bottom-most option colored:
![alternate context menu](https://dl.dropboxusercontent.com/u/11093974/Junk/contextmenu.png)
- Fixed context menu not updating when config was reloaded

When reloading the config file, the context menu settings wouldn't update. At first I was very confused what the "ContextMenuShowMargins" options did, because upon refreshing I noticed no difference. Hopefully this should avoid confusion for anyone else!
