### PR TITLE
Load only if the file given exists

### DIFF
--- a/vimage/Source/Program.cs
+++ b/vimage/Source/Program.cs
@@ -11,20 +11,14 @@ namespace vimage
         {
             string file;
             if (args.Length == 0)
-            {
-#if DEBUG
-                //file = @"C:\Users\Corey\Pictures\Test Images\Beaver_Transparent.png";
-                //file = @"C:\Users\Corey\Pictures\Test Images\AdventureTime_TransparentAnimation.gif";
-                //file = @"C:\Users\Corey\Pictures\Test Images\AnimatedGif.gif";
-                file = @"G:\Misc\Desktop Backgrounds\0diHF.jpg";
-#else
                 return;
-#endif
-            }
             else
                 file = args[0];
 
-            ImageViewer ImageViewer = new ImageViewer(file);
+            if (System.IO.File.Exists(file))
+            {
+                ImageViewer imageViewer = new ImageViewer(file);
+            }
         }
     }
 }


### PR DESCRIPTION
This should fix the bug for people who compile the project for themselves and happen to crash immediately because hard-coded non-existent (on my computer) files.
I think the default action for the start on missing file should be the "take no action".

Keep up the good work, nice image viewer! :ship:
